### PR TITLE
fix(swiftpm): Provide URL to artifact on Swift PM registry

### DIFF
--- a/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
+++ b/plugins/package-managers/swiftpm/src/main/kotlin/SwiftPm.kt
@@ -16,15 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
+@file:Suppress("TooManyFunctions")
 
 package org.ossreviewtoolkit.plugins.packagemanagers.swiftpm
 
 import java.io.File
 
+import org.apache.logging.log4j.kotlin.logger
+
 import org.ossreviewtoolkit.analyzer.PackageManager
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.downloader.VcsHost
 import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.model.Hash
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.Package
@@ -93,9 +97,20 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
             }
         }
 
+        val localSwiftPackageRegistryConfiguration = readLocalSwiftPackageRegistryConfiguration(analysisRoot)
+
         return when (definitionFile.name) {
-            PACKAGE_SWIFT_NAME -> resolveDefinitionFileDependencies(analysisRoot, definitionFile)
-            else -> resolveLockfileDependencies(analysisRoot, definitionFile)
+            PACKAGE_SWIFT_NAME -> resolveDefinitionFileDependencies(
+                analysisRoot = analysisRoot,
+                packageSwiftFile = definitionFile,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
+
+            else -> resolveLockfileDependencies(
+                analysisRoot = analysisRoot,
+                packageResolvedFile = definitionFile,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
         }
     }
 
@@ -105,25 +120,31 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
      */
     private fun resolveLockfileDependencies(
         analysisRoot: File,
-        packageResolvedFile: File
+        packageResolvedFile: File,
+        localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
     ): List<ProjectAnalyzerResult> {
         val issues = mutableListOf<Issue>()
         val packages = mutableSetOf<Package>()
         val scopeDependencies = mutableSetOf<Scope>()
 
-        parseLockfile(packageResolvedFile).onSuccess { pins ->
-            pins.mapTo(packages) { it.toPackage() }
-            scopeDependencies += Scope(
-                name = DEPENDENCIES_SCOPE_NAME,
-                dependencies = packages.mapTo(mutableSetOf()) { it.toReference(linkage = PackageLinkage.DYNAMIC) }
-            )
-        }.onFailure {
-            issues += createAndLogIssue(it.message.orEmpty())
-        }
+        parseLockfile(packageResolvedFile)
+            .onSuccess { pins ->
+                pins.mapTo(packages) { it.toPackage(localSwiftPackageRegistryConfiguration) }
+                scopeDependencies += Scope(
+                    name = DEPENDENCIES_SCOPE_NAME,
+                    dependencies = packages.mapTo(mutableSetOf()) { it.toReference(linkage = PackageLinkage.DYNAMIC) }
+                )
+            }.onFailure {
+                issues += createAndLogIssue(it.message.orEmpty())
+            }
 
         return listOf(
             ProjectAnalyzerResult(
-                project = projectFromDefinitionFile(analysisRoot, packageResolvedFile, scopeDependencies),
+                project = projectFromDefinitionFile(
+                    analysisRoot = analysisRoot,
+                    definitionFile = packageResolvedFile,
+                    scopeDependencies = scopeDependencies
+                ),
                 packages = packages,
                 issues = issues
             )
@@ -137,7 +158,8 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
      */
     private fun resolveDefinitionFileDependencies(
         analysisRoot: File,
-        packageSwiftFile: File
+        packageSwiftFile: File,
+        localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
     ): List<ProjectAnalyzerResult> {
         val swiftPackage = getSwiftPackage(packageSwiftFile)
 
@@ -147,20 +169,34 @@ class SwiftPm(override val descriptor: PluginDescriptor = SwiftPmFactory.descrip
         val pinsByIdentity = mutableMapOf<String, PinV2>()
 
         val lockfile = packageSwiftFile.resolveSibling(PACKAGE_RESOLVED_NAME)
+
         if (lockfile.isFile) {
             // The command `swift package show-dependencies` does not create a (non-existing) lockfile in case there
             // are no non-local dependencies.
-            parseLockfile(lockfile).onSuccess { pins ->
-                pins.associateByTo(pinsByIdentity) { it.identity }
-            }.onFailure {
-                issues += createAndLogIssue(it.message.orEmpty())
-            }
+            parseLockfile(lockfile)
+                .onSuccess { pins ->
+                    pins.associateByTo(pinsByIdentity) { it.identity }
+                }
+                .onFailure {
+                    issues += createAndLogIssue(it.message.orEmpty())
+                }
         }
 
-        swiftPackage.getTransitiveDependencies().mapTo(packages) { it.toPackage(pinsByIdentity) }
+        swiftPackage.getTransitiveDependencies().mapTo(packages) {
+            it.toPackage(
+                pinsByIdentity = pinsByIdentity,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
+        }
+
         scopeDependencies += Scope(
             name = DEPENDENCIES_SCOPE_NAME,
-            dependencies = swiftPackage.dependencies.mapTo(mutableSetOf()) { it.toPackageReference(pinsByIdentity) }
+            dependencies = swiftPackage.dependencies.mapTo(mutableSetOf()) {
+                it.toPackageReference(
+                    pinsByIdentity = pinsByIdentity,
+                    localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+                )
+            }
         )
 
         return listOf(
@@ -222,13 +258,37 @@ private fun SwiftPackage.toId(pinsByIdentity: Map<String, PinV2>): Identifier =
 private fun SwiftPackage.toVcsInfo(pinsByIdentity: Map<String, PinV2>): VcsInfo =
     pinsByIdentity[identity]?.toVcsInfo() ?: VcsHost.parseUrl(url)
 
-private fun SwiftPackage.toPackage(pinsByIdentity: Map<String, PinV2>): Package =
-    createPackage(toId(pinsByIdentity), toVcsInfo(pinsByIdentity))
+private fun SwiftPackage.sourceArtifact(
+    pinsByIdentity: Map<String, PinV2>,
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): RemoteArtifact =
+    pinsByIdentity[identity]?.sourceArtifact(localSwiftPackageRegistryConfiguration) ?: RemoteArtifact.EMPTY
 
-private fun SwiftPackage.toPackageReference(pinsByIdentity: Map<String, PinV2>): PackageReference =
+private fun SwiftPackage.toPackage(
+    pinsByIdentity: Map<String, PinV2>,
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): Package =
+    createPackage(
+        id = toId(pinsByIdentity),
+        vcsInfo = toVcsInfo(pinsByIdentity),
+        sourceArtifact = sourceArtifact(
+            pinsByIdentity = pinsByIdentity,
+            localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+        )
+    )
+
+private fun SwiftPackage.toPackageReference(
+    pinsByIdentity: Map<String, PinV2>,
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): PackageReference =
     PackageReference(
         id = toId(pinsByIdentity),
-        dependencies = dependencies.mapTo(mutableSetOf()) { it.toPackageReference(pinsByIdentity) }
+        dependencies = dependencies.mapTo(mutableSetOf()) {
+            it.toPackageReference(
+                pinsByIdentity = pinsByIdentity,
+                localSwiftPackageRegistryConfiguration = localSwiftPackageRegistryConfiguration
+            )
+        }
     )
 
 private fun SwiftPackage.getTransitiveDependencies(): Set<SwiftPackage> {
@@ -274,15 +334,56 @@ private fun PinV2.toVcsInfo(): VcsInfo {
     )
 }
 
-private fun PinV2.toPackage(): Package = createPackage(toId(), toVcsInfo())
+private fun PinV2.sourceArtifact(
+    localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?
+): RemoteArtifact {
+    return if (kind == PinV2.Kind.REGISTRY) {
+        val userLevelSwiftPackageRegistryConfiguration = readUserLevelSwiftPackageRegistryConfiguration()
 
-private fun createPackage(id: Identifier, vcsInfo: VcsInfo) =
+        // Identifier for registry entries have the following format: <SCOPE>.<NAME>
+        val scope = identity.substringBefore(".")
+        val name = identity.substringAfter(".")
+
+        val registry = localSwiftPackageRegistryConfiguration?.registry(scope)
+            ?: userLevelSwiftPackageRegistryConfiguration?.registry(scope)
+
+        return if (registry != null) {
+            // registry.url only contains the base URL of the registry
+            // We need to append identity where all "." are replaced with slashes
+            var url = registry.url
+            if (!registry.url.endsWith("/")) {
+                url += "/"
+            }
+
+            url += identity.replace(oldValue = ".", newValue = "/")
+            url += "/"
+            url += "$name-${state?.version}.zip"
+
+            RemoteArtifact(url = url, hash = Hash.NONE)
+        } else {
+            logger.warn { "Unable to determine Swift PM registry for: '$identity'" }
+            RemoteArtifact.EMPTY
+        }
+    } else {
+        RemoteArtifact.EMPTY
+    }
+}
+
+private fun PinV2.toPackage(localSwiftPackageRegistryConfiguration: SwiftPackageRegistryConfiguration?): Package {
+    return createPackage(
+        id = toId(),
+        vcsInfo = toVcsInfo(),
+        sourceArtifact = sourceArtifact(localSwiftPackageRegistryConfiguration)
+    )
+}
+
+private fun createPackage(id: Identifier, vcsInfo: VcsInfo, sourceArtifact: RemoteArtifact) =
     Package(
         vcs = vcsInfo,
         description = "",
         id = id,
         binaryArtifact = RemoteArtifact.EMPTY,
-        sourceArtifact = RemoteArtifact.EMPTY,
+        sourceArtifact = sourceArtifact,
         declaredLicenses = emptySet(), // SPM files do not declare any licenses.
         homepageUrl = ""
     )
@@ -299,4 +400,8 @@ internal fun getCanonicalName(repositoryUrl: String): String {
     return normalizedUrl.toUri {
         it.host + it.path.removeSuffix(".git")
     }.getOrDefault(normalizedUrl).lowercase()
+}
+
+private fun SwiftPackageRegistryConfiguration.registry(scope: String): SwiftPackageRegistryConfiguration.Registry? {
+    return registries[scope]
 }


### PR DESCRIPTION
Read local and user level swift registry configurations to be able to provide the source artifact URL for dependencies fetched over a Swift PM Registry.